### PR TITLE
Iss1790 - Wrapping kafka-clients and dependencies into a new OSGi bundle

### DIFF
--- a/com.auth0.jwt/pom.xml
+++ b/com.auth0.jwt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.32.0</version>
+		<version>0.33.0</version>
 	</parent>
 
 	<artifactId>com.auth0.jwt</artifactId>

--- a/com.google.gson.eclipse/pom.xml
+++ b/com.google.gson.eclipse/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.31.0</version>
+		<version>0.32.0</version>
 	</parent>
 
 	<artifactId>gson-eclipse</artifactId>

--- a/com.google.gson.eclipse/pom.xml
+++ b/com.google.gson.eclipse/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.32.0</version>
+		<version>0.33.0</version>
 	</parent>
 
 	<artifactId>gson-eclipse</artifactId>

--- a/com.google.gson/pom.xml
+++ b/com.google.gson/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.31.0</version>
+		<version>0.32.0</version>
 	</parent>
 
 	<artifactId>gson</artifactId>

--- a/com.google.gson/pom.xml
+++ b/com.google.gson/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.32.0</version>
+		<version>0.33.0</version>
 	</parent>
 
 	<artifactId>gson</artifactId>

--- a/com.jcraft.jsch/pom.xml
+++ b/com.jcraft.jsch/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.32.0</version>
+		<version>0.33.0</version>
 	</parent>
 
 	<artifactId>com.jcraft.jsch</artifactId>

--- a/com.jcraft.jsch/pom.xml
+++ b/com.jcraft.jsch/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.31.0</version>
+		<version>0.32.0</version>
 	</parent>
 
 	<artifactId>com.jcraft.jsch</artifactId>

--- a/io.grpc.java/pom.xml
+++ b/io.grpc.java/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.32.0</version>
+		<version>0.33.0</version>
 	</parent>
 
 	<artifactId>io.grpc.java</artifactId>

--- a/io.grpc.java/pom.xml
+++ b/io.grpc.java/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.31.0</version>
+		<version>0.32.0</version>
 	</parent>
 
 	<artifactId>io.grpc.java</artifactId>

--- a/javax.transaction/pom.xml
+++ b/javax.transaction/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.32.0</version>
+		<version>0.33.0</version>
 	</parent>
 
 	<artifactId>jta</artifactId>

--- a/javax.transaction/pom.xml
+++ b/javax.transaction/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.31.0</version>
+		<version>0.32.0</version>
 	</parent>
 
 	<artifactId>jta</artifactId>

--- a/kafka.clients/pom.xml
+++ b/kafka.clients/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-wrapping-parent</artifactId>
-		<version>0.32.0</version>
+		<version>0.33.0</version>
 	</parent>
 
 	<artifactId>kafka.clients</artifactId>

--- a/kafka.clients/pom.xml
+++ b/kafka.clients/pom.xml
@@ -9,32 +9,27 @@
 		<version>0.32.0</version>
 	</parent>
 
-	<artifactId>com.auth0.jwt</artifactId>
-	<version>4.4.0</version>
+	<artifactId>kafka.clients</artifactId>
+	<version>3.7.0</version>
 	<packaging>bundle</packaging>
 
-	<name>Galasa wrapped version of auth0 JWT</name>
+	<name>Galasa wrapped version of the kafka-client package</name>
 
 	<dependencies>
 		<dependency>
-			<groupId>com.auth0</groupId>
-			<artifactId>java-jwt</artifactId>
-			<version>4.4.0</version>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>3.7.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.14.2</version>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-server-common</artifactId>
+			<version>3.7.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>2.14.2</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-annotations</artifactId>
-			<version>2.14.2</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.30</version>
 		</dependency>
 	</dependencies>
 
@@ -47,13 +42,22 @@
 				<configuration>
 					<supportedProjectTypes>bundle</supportedProjectTypes>
 					<instructions>
-						<Bundle-SymbolicName>com.auth0.jwt</Bundle-SymbolicName>
+						<Bundle-SymbolicName>kafka.clients</Bundle-SymbolicName>
 						<Embed-Dependency>*;scope=compile</Embed-Dependency>
-						<Export-Package>com.auth0.jwt,
-							com.auth0.jwt.JWT,
-							com.auth0.jwt.algorithms,
-							com.auth0.jwt.exceptions,
-							com.auth0.jwt.interfaces
+						<Import-Package>
+							org.slf4j,
+							javax.net.ssl
+						</Import-Package>
+						<Export-Package>
+							org.apache.kafka.clients,
+							org.apache.kafka.clients.admin,
+							org.apache.kafka.clients.consumer,
+							org.apache.kafka.clients.producer,
+							org.apache.kafka.common,
+							org.apache.kafka.common.serialization,
+							org.apache.kafka.server,
+							org.apache.kafka.shaded,
+							common.message
 						</Export-Package>
 					</instructions>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-wrapping-parent</artifactId>
-	<version>0.31.0</version>
+	<version>0.32.0</version>
 	<packaging>pom</packaging>
 
 	<name>Galasa OSGi Wrapping</name>
@@ -53,6 +53,7 @@
 		<module>com.google.gson.eclipse</module>
 		<module>javax.transaction</module>
 		<module>io.grpc.java</module>
+		<module>kafka.clients</module>
 	</modules>
 
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-wrapping-parent</artifactId>
-	<version>0.32.0</version>
+	<version>0.33.0</version>
 	<packaging>pom</packaging>
 
 	<name>Galasa OSGi Wrapping</name>


### PR DESCRIPTION
Kafka's Java libraries are not OSGi bundles so to be imported into and used in Galasa to allow us to develop our own Kafka Producer, it must be wrapped into an OSGi bundle, or the Felix Framework will not be able to initialise the bundle.

This PR:
- upgrades the galasa-wrapping-parent to version 0.33.0 to match the current development version 
- creates a new Maven artefact `kafka.clients` which wraps kafka-clients and it's needed dependencies into an OSGi bundle