### PR TITLE
fix up local build script so it stops when there is a build failure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Snap.*
 bin/
 lib/
 dependency-reduced-pom.xml
+
+# Don't check-in IDE specific files if we can help it.
+.vscode

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -40,26 +40,16 @@ blue=$(tput setaf 25)
 # Headers and Logging
 #
 #-----------------------------------------------------------------------------------------                   
-underline() { printf "${underline}${bold}%s${reset}\n" "$@"
-}
-h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
-}
-h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
-}
-debug() { printf "${white}%s${reset}\n" "$@"
-}
-info() { printf "${white}➜ %s${reset}\n" "$@"
-}
-success() { printf "${green}✔ %s${reset}\n" "$@"
-}
-error() { printf "${red}✖ %s${reset}\n" "$@"
-}
-warn() { printf "${tan}➜ %s${reset}\n" "$@"
-}
-bold() { printf "${bold}%s${reset}\n" "$@"
-}
-note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
-}
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
 #-----------------------------------------------------------------------------------------                   
 # Functions
@@ -159,11 +149,7 @@ EOF
 
 mvn clean install -Dgpg.passphrase=${gpg_passphrase} \
 2>&1 >> ${log_file}
-rc=$? ; if [[ "${rc}" != "0" ]]; then 
-    error "Failed to build ${project}" 
-    info "See log file at ${log_file}"
-    exit 1
-fi
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to build ${project}" ; info "See log file at ${log_file}" ; exit 1 ; fi
 success "Built OK"
 
 success "Project ${project} built - OK - log is at ${log_file}"


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

## Why ?

The build scripts failed, but still continued to run the javadoc steps.
Needed to stop the javadoc stuff clouding-out the detail that the build failed above it.
And it looked like a successful build as a result.

Also, stop .vscode settings being delivered into the repo.
