### PR TITLE
Iss1898 - Upgrade GSON wrapper dependency version

### DIFF
--- a/com.google.gson/pom.xml
+++ b/com.google.gson/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>gson</artifactId>
-	<version>2.8.5</version>
+	<version>2.10.1</version>
 	<packaging>bundle</packaging>
 
 	<name>galasa wrapped version of GSON</name>
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
+			<version>2.10.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
### Why?

To remove vulnerabilities in GSON 2.8.5. For story https://github.com/galasa-dev/projectmanagement/issues/1898