### PR TITLE
Updating GH workflows with new base-image location 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,9 +106,8 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-            # Temporary: dockerRepository will change to ghcr.io once the Wrapping image is available there
           build-args: |
-            dockerRepository=harbor.galasa.dev
+            dockerRepository=ghcr.io
             baseVersion=latest
 
       # Recycle the development Maven registry app in ArgoCD

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -98,7 +98,6 @@ jobs:
           push: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          # dockerRepository will change to ghcr.io once the Wrapping image is available there
           build-args: |
-            dockerRepository=harbor.galasa.dev
+            dockerRepository=ghcr.io
             baseVersion=latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -75,18 +75,7 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {
-    ".github/workflows/build.yaml": [
-      {
-        "hashed_secret": "2ef5c1fbcf50a4f18ecf5771534b5f5b88a46e83",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 27,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ]
-  },
+  "results": {},
   "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -75,7 +75,18 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
+  "results": {
+    ".github/workflows/build.yaml": [
+      {
+        "hashed_secret": "2ef5c1fbcf50a4f18ecf5771534b5f5b88a46e83",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
   "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,

--- a/dockerfiles/dockerfile.wrapping
+++ b/dockerfiles/dockerfile.wrapping
@@ -1,6 +1,6 @@
 ARG dockerRepository
 ARG baseVersion
-FROM ${dockerRepository}/galasadev/galasa-base:${baseVersion}
+FROM ${dockerRepository}/galasa-dev/base-image:${baseVersion}
 
 COPY repo/ /usr/local/apache2/htdocs/
 COPY wrapping.githash /usr/local/apache2/htdocs/wrapping.githash


### PR DESCRIPTION
## Why?

Updating the Dockerfile FROM and the required build arguments to use the new base-image in GHCR now its available.