### PR TITLE
upgrade jackson to avoid a DOS vulnerability

### DIFF
--- a/com.auth0.jwt/pom.xml
+++ b/com.auth0.jwt/pom.xml
@@ -24,17 +24,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.14.2</version>
+			<version>2.16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.14.2</version>
+			<version>2.16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.14.2</version>
+			<version>2.16.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
jackson-core 2.14.2 has a vulnerability which can be avoided by bumping up the version.

Chose to upgrade to 2.16.0 because the Kafka module already pulls in jackson core. So they now match.