### PR TITLE
remove maven cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'semeru'
-          cache: maven
 
       # The githash is added to the development Maven registry to show what commit level it contains
       - name: Print githash

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -28,7 +28,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'semeru'
-          cache: maven
 
       # The githash is added to the development Maven registry to show what commit level it contains
       - name: Print githash


### PR DESCRIPTION
stops the build from pulling the latest of its dependencies.