### PR TITLE
Remove workflow_dispatch event for pr wrapping build

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -6,7 +6,6 @@
 name: PR build
 
 on:
-  workflow_dispatch:
   pull_request:
       branches: [main]
 


### PR DESCRIPTION
Only main builds should have `workflow_dispatch` events as PR builds should only be triggered by the openings of PRs.